### PR TITLE
NPM Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
-  "name": "@flucoma/fav.js",
+  "name": "@flucoma/fav",
   "version": "0.0.1",
   "description": "A javascript library for flexible audio visualization",
-  "main": "FAV.js",
+  "main": "dist/FAV.js",
+  "files": [
+	"dist/FAV.js",
+	"src/*.js"
+  ],
   "directories": {
     "example": "examples"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fav.js",
+  "name": "@flucoma/fav.js",
   "version": "0.0.1",
   "description": "A javascript library for flexible audio visualization",
   "main": "FAV.js",


### PR DESCRIPTION
This makes the fav.js package available via npm by publishing it to the FluCoMa organisation.

- update name to be flucoma namespaced
- ignore pnpm locks
- update name and files
