### PR TITLE
patching-resample-exception in samplers.js

### DIFF
--- a/src/samplers.js
+++ b/src/samplers.js
@@ -13,7 +13,7 @@ module.exports = {
       if(bucketStart > this.data.length - 1 ) bucketStart = this.data.length -1;
       if(bucketEnd > this.data.length -1 ) bucketEnd = this.data.length -1;
       if(bucketStart === bucketEnd) {
-        if(i>0) newData[i]  = newData[i-1];
+        newData[I] = this.data[bucketStart];
       }
       else newData[i]  = stats[method](this.data.slice(bucketStart, bucketEnd));
     }


### PR DESCRIPTION
when the step is smaller than 1, the copying of the input[bucketStart] saves issues and is more straightforward.